### PR TITLE
Fix #1: add run instructions and env docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,86 @@
+# whisper-api
+
+HTTP API + Celery worker for audio transcription using OpenAI Whisper (plus optional diarization / LLM post-processing depending on configuration).
+
+## Quickstart (Docker Compose)
+
+### 1) Configure environment
+
+```bash
+cp .env.example .env
+# edit .env as needed (ports, secrets, etc.)
+```
+
+### 2) Start services
+
+```bash
+docker compose up --build
+```
+
+This starts:
+- `whisper-api` (Flask dev server)
+- `celery-worker`
+- `redis`
+
+API will be exposed on `${APP_PORT}`.
+
+### 3) Stop
+
+```bash
+docker compose down
+```
+
+## Local development (no Docker)
+
+### Prereqs
+- Python 3.x
+- Redis (running locally or reachable remotely)
+
+### Setup
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+
+cp .env.example .env
+# edit .env
+```
+
+### Run the API
+
+`run.py` loads `.env` and runs the Flask app.
+
+```bash
+python -m run
+```
+
+### Run the worker
+
+```bash
+celery -A run.celery worker --loglevel=info --concurrency=1
+```
+
+## Configuration
+
+- Environment variables are loaded from `.env` (see `.env.example`).
+- Docker Compose also injects `WHISPER_MODEL=large` by default (see `docker-compose.yml`).
+
+More details: see [`docs/ENVIRONMENT.md`](docs/ENVIRONMENT.md).
+
+## Notes on production
+
+The current compose setup runs the Flask development server. For production deployments you’ll typically want a production WSGI server (e.g., gunicorn) and to review:
+- concurrency settings for Celery
+- volume/cache strategy (`../whisper-cache:/root/.cache`)
+- secrets management (do not commit `.env`)
+
+## Repository layout (current)
+
+- `app/api`: HTTP resources/actions/requests
+- `app/services`: service layer / business logic
+- `app/tasks`: Celery tasks
+- `app/extensions`: Flask/Celery/JWT/Socket.IO extensions
+- `app/config`: configuration objects
+
+A larger Clean Architecture re-organization is tracked in #1 and is best done incrementally after agreeing on a target `docs/ARCHITECTURE.md`.

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -1,0 +1,40 @@
+# Environment variables
+
+This service is configured primarily via environment variables loaded from a `.env` file.
+
+## Setup
+
+```bash
+cp .env.example .env
+# then edit .env
+```
+
+Docker Compose uses:
+
+- `env_file: .env`
+- `ports: "${APP_PORT}:${APP_PORT}"`
+- Redis port: `"${REDIS_PORT}:${REDIS_PORT}"`
+
+## Common variables
+
+The canonical list is in `.env.example`. Some key variables used by entrypoints/compose:
+
+### Runtime
+- `APP_ENV`: used in container naming (`${APP_ENV}-whisper-api`, `${APP_ENV}-celery-worker`, `${APP_ENV}-redis`).
+- `APP_PORT`: Flask binds to this port (`run.py`) and compose publishes it.
+
+### Redis / Celery
+- `REDIS_PORT`: port exposed by the `redis` service in compose.
+
+Celery worker is started as:
+
+```bash
+celery -A run.celery worker --loglevel=info --concurrency=1
+```
+
+### Whisper model
+- `WHISPER_MODEL`: in `docker-compose.yml` it is set to `large` by default under the API service.
+
+## Notes
+- Do not commit `.env` (keep secrets out of git).
+- If you run without Docker, you must ensure Redis is reachable and that your `.env` points to it.


### PR DESCRIPTION
Closes #1

## What this PR does
Adds missing documentation to make the project runnable without reading source code:
- Root `README.md` with development and Docker Compose run instructions (API + Celery worker + Redis).
- `docs/ENVIRONMENT.md` describing the `.env` flow and key environment variables referenced by `run.py` and `docker-compose.yml`.

## Scope / follow-ups
This PR intentionally **does not** attempt a full Clean Architecture refactor (that is a large, cross-cutting change). A recommended next step is to add `docs/ARCHITECTURE.md` + do a slice-by-slice migration of `app/api` → use-cases → domain → infrastructure.

## Self-Review
- Verified compose entrypoints referenced in docs match `docker-compose.yml` (`python3 -B -m run`, `celery -A run.celery worker ...`).
- Confirmed `run.py` loads `.env` and uses `APP_PORT` as documented.
- Ensured docs don’t introduce new dependencies.