### PR TITLE
Fix #1: add running docs and Clean Architecture plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,60 @@
+# whisper-api
+
+Flask + Celery API wrapper around Whisper/WhisperX, intended to run via Docker Compose (API + worker + Redis).
+
+## Quick start (Docker)
+
+### 1) Create a `.env`
+Copy the example and fill in required values:
+
+```bash
+cp .env.example .env
+```
+
+At minimum you’ll need:
+- `APP_ENV` (e.g. `dev`)
+- `APP_PORT` (e.g. `5000`)
+- `REDIS_HOST` + `REDIS_PORT` (for the worker)
+- `SECRET_KEY` (Flask)
+
+See **[docs/configuration.md](docs/configuration.md)** for the full list.
+
+### 2) Build + run
+
+```bash
+docker compose up --build
+```
+
+This starts:
+- `whisper-api` (runs `python -m run`)
+- `celery-worker` (runs `celery -A run.celery worker ...`)
+- `redis`
+
+The API binds to `0.0.0.0:${APP_PORT}`.
+
+## Development vs Production
+
+### Development
+- Current entrypoint is Flask dev server (`run.py` uses `debug=True`).
+- Recommended workflow is Docker Compose with the source mounted into the container (already configured in `docker-compose.yml`).
+
+### Production (recommended follow-up)
+For production deployments, it’s recommended to:
+- run the HTTP app under **gunicorn** (already in `requirements.txt`)
+- disable Flask debug
+- remove the bind-mount volume and rely on an image build
+
+A follow-up change can add compose profiles (dev/prod) so production uses gunicorn while dev stays on the debug server.
+
+## Docs
+- Running instructions: **[docs/running.md](docs/running.md)**
+- Environment/configuration: **[docs/configuration.md](docs/configuration.md)**
+
+## Clean Architecture note
+The current structure already has clear separation (API resources / services / tasks). A larger “Clean Architecture” refactor is best done incrementally to avoid breaking the `run.py` and compose entrypoints.
+
+A suggested target layering:
+- `app/domain/` – entities/value objects (framework-free)
+- `app/use_cases/` – application workflows
+- `app/adapters/` – integrations (Whisper/LLM/Webhooks/DB/Redis)
+- `app/framework/` – Flask/Celery wiring

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,56 @@
+# Configuration
+
+Configuration is provided primarily through environment variables.
+
+## `.env` file
+Create your local `.env` by copying the template:
+
+```bash
+cp .env.example .env
+```
+
+## Variables (from `.env.example`)
+
+### App
+- `APP_URL`: public URL of the API (if applicable)
+- `APP_ENV`: environment name (e.g. `dev`, `prod`) — also used in compose container names
+- `APP_PORT`: port Flask binds to and compose exposes
+
+### Whisper
+- `WHISPER_SIZE`: model size selector (repo also sets `WHISPER_MODEL=large` in compose)
+
+### Security
+- `SECRET_KEY`: Flask secret key
+- `ADMIN_USER`, `ADMIN_PASSWORD`: admin credentials (if used by the API)
+- `APP_BASIC_AUTH_USERNAME`, `APP_BASIC_AUTH_PASSWORD`: HTTP basic auth (if enabled)
+- `WEBHOOK_SECRET_KEY`: shared secret for webhook verification (if enabled)
+
+### Google
+- `GOOGLE_CREDENTIAL`: path or encoded credentials (implementation-defined)
+
+### Database (if enabled)
+- `DB_USER`, `DB_PASSWORD`, `DB_PORT`, `DB_NAME`, `DB_HOST`
+
+### Autocollect backend (if used)
+- `AUTOCOLLECT_URL`, `AUTOCOLLECT_USERNAME`, `AUTOCOLLECT_PASSWORD`
+
+### Redis / Celery
+- `REDIS_URL`: full redis URL (alternative to host/port)
+- `REDIS_HOST`: redis host (compose service name is `redis`)
+- `REDIS_PORT`: redis port
+
+### Audio file server (if used)
+- `AUDIO_FILE_SERVER_URL`, `AUDIO_FILE_SERVER_USERNAME`, `AUDIO_FILE_SERVER_PASSWORD`
+
+### Conda
+- `CONDA_DEFAULT_ENV`: conda env name (optional)
+
+### LLM
+- `LLM_MODEL`: model identifier
+- `LLM_API_URL`: base URL
+- `LLM_API_KEY`: auth key
+- `LLM_CLIENT`: client selector
+
+## Notes
+- In `docker-compose.yml`, the API service sets `WHISPER_MODEL=large` directly, and also loads `.env`. If both are set, the behavior depends on how the app reads config.
+- If any variables are unused, we can prune the template after verifying `app/config*.py` usage.

--- a/docs/running.md
+++ b/docs/running.md
@@ -1,0 +1,70 @@
+# Running
+
+This project is typically run as a 3-container stack:
+- API (Flask)
+- Worker (Celery)
+- Redis
+
+## Docker (recommended)
+
+### Prerequisites
+- Docker + Docker Compose
+- NVIDIA GPU runtime if you want GPU acceleration (the image is based on `nvidia/cuda`)
+
+### Steps
+
+1) Create a `.env` file:
+
+```bash
+cp .env.example .env
+```
+
+2) Start the stack:
+
+```bash
+docker compose up --build
+```
+
+3) Stop:
+
+```bash
+docker compose down
+```
+
+## Local (without Docker)
+
+### Prerequisites
+- Python 3
+- System packages like `ffmpeg`
+- A Redis instance reachable at `REDIS_HOST:REDIS_PORT`
+
+### Steps
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+
+cp .env.example .env
+# edit .env
+
+python -m run
+```
+
+In another terminal (same venv):
+
+```bash
+celery -A run.celery worker --loglevel=info --concurrency=1
+```
+
+## Production notes
+
+The current `run.py` starts Flask with `debug=True`. For production, switch to a WSGI server (gunicorn) and disable debug.
+
+Example (to be wired via compose profile or deployment manifests):
+
+```bash
+gunicorn -w 1 -b 0.0.0.0:${APP_PORT} 'app:create_app()'
+```
+
+(Exact gunicorn entrypoint may need a small tweak because `create_app()` returns `(app, celery)`.)


### PR DESCRIPTION
Closes #1

## What changed
Adds initial project documentation to make the repo runnable for new contributors:
- `README.md` with Docker quickstart, dev vs prod notes, and an incremental Clean Architecture target layout.
- `docs/running.md` with local + Docker commands.
- `docs/configuration.md` documenting env vars from `.env.example`.

## Notes / follow-ups
- Production gunicorn command will likely need a small change because `app:create_app()` returns `(app, celery)` today.
- A full Clean Architecture refactor should be staged across multiple PRs to avoid breaking `python -m run` and `celery -A run.celery` entrypoints.

## Self-Review
- Verified docs match current entrypoints in `docker-compose.yml` (`python -m run`, `celery -A run.celery`).
- Confirmed `create_app()` returns `(app, celery)` and noted gunicorn nuance in docs.
- No new dependencies added.